### PR TITLE
Issue/22 vimeo length parsing

### DIFF
--- a/vast.py
+++ b/vast.py
@@ -54,26 +54,6 @@ def get_youtube_video_length(response, youtube_link):
         # Update the appropriate time value in the youtube_link
         youtube_link[YOUTUBE_TIMESTAMP_POSITION_MAP[timestamp[-1]]] = timestamp[:-1]
 
-# def get_vimeo_video_length(response, vimeo_link):
-#     """
-#     Determines the length of a Vimeo video and updates the information in VAST report accordingly.
-#
-#     :param response: The response from the Vimeo Video API.
-#     :type response: requests.Response
-#     :param vimeo_link: The data structure holding information about the Vimeo video.
-#     :type vimeo_link: List
-#     """
-#
-#     # Send a GET request of the vimeo_link URL to the api.vimeo.com/videos?links={} endpoint
-#
-#     # Parse the 'video_id' field from the provided response
-#
-#     # Send a GET request to the api.vimeo.com/videos/{video_id} endpoint
-#
-#     # Parse the 'duration' field from the provided response
-#
-#     # Populate the appropriate column in the VAST report with seconds
-
 # Checks all pages in a canvas course for media links
 print('Checking Pages')
 pages = course.get_pages()

--- a/vast.py
+++ b/vast.py
@@ -54,6 +54,24 @@ def get_youtube_video_length(response, youtube_link):
         # Update the appropriate time value in the youtube_link
         youtube_link[YOUTUBE_TIMESTAMP_POSITION_MAP[timestamp[-1]]] = timestamp[:-1]
 
+def get_vimeo_video_length(response, video_id):
+    """
+    Determines the length of a Vimeo video from the video ID provides and updates the information in VAST report accordingly.
+
+    :param response: The response from the Vimeo Video API.
+    :type response: requests.Response
+    :param video_id: The ID of the Vimeo video.
+    :type video_id: int
+    """
+
+    # Parse the Vimeo URL to recieve the video_id
+
+    # Send a GET request to the api.vimeo.com/videos/{video_id} endpoint
+
+    # Receive the 'duration' field from the provided response
+
+    # Populate the appropriate column in the VAST report with seconds
+
 # Checks all pages in a canvas course for media links
 print('Checking Pages')
 pages = course.get_pages()

--- a/vast.py
+++ b/vast.py
@@ -333,6 +333,12 @@ for link in vimeo_link:
                         vimeo_captions.append('1')
                     else:
                         vimeo_captions.append('2')
+                r = requests.get(
+                    'https://api.vimeo.com/videos/{}'.format(video_id),
+                    headers={'Authorization': 'Bearer {}'.format(vimeo_api_key)}
+                )
+                data = r.json()
+                vimeo_duration = data['duration']
                 if '1' in vimeo_captions:
                     vimeo_link[link].insert(0, 'Captions in English')
                     vimeo_link[link].insert(1, '')
@@ -340,12 +346,6 @@ for link in vimeo_link:
                     vimeo_link[link].insert(3, '')
                 else:
                     vimeo_link[link].insert(0, 'No English Captions')
-                    r = requests.get(
-                        'https://api.vimeo.com/videos/{}'.format(video_id),
-                        headers={'Authorization': 'Bearer {}'.format(vimeo_api_key)}
-                    )
-                    data = r.json()
-                    vimeo_duration = data['duration']
                     vimeo_link[link].insert(1, '')
                     vimeo_link[link].insert(2, '')
                     vimeo_link[link].insert(3, vimeo_duration)

--- a/vast.py
+++ b/vast.py
@@ -279,8 +279,6 @@ for link in vimeo_link:
                 )
                 data = r.json()
                 vimeo_duration = data['duration']
-                # hour, remainder = divmod(vimeo_duration, 3600)
-                # minute, second = divmod(remainder, 60)
                 vimeo_link[link].insert(1, '')
                 vimeo_link[link].insert(2, '')
                 vimeo_link[link].insert(3, vimeo_duration)
@@ -326,8 +324,6 @@ for link in vimeo_link:
                 )
                 data = r.json()
                 vimeo_duration = data['duration']
-                # hour, remainder = divmod(vimeo_duration, 3600)
-                # minute, second = divmod(remainder, 60)
                 vimeo_link[link].insert(1, '')
                 vimeo_link[link].insert(2, '')
                 vimeo_link[link].insert(3, vimeo_duration)
@@ -350,8 +346,6 @@ for link in vimeo_link:
                     )
                     data = r.json()
                     vimeo_duration = data['duration']
-                    # hour, remainder = divmod(vimeo_duration, 3600)
-                    # minute, second = divmod(remainder, 60)
                     vimeo_link[link].insert(1, '')
                     vimeo_link[link].insert(2, '')
                     vimeo_link[link].insert(3, vimeo_duration)

--- a/vast.py
+++ b/vast.py
@@ -288,8 +288,15 @@ for link in vimeo_link:
                         vimeo_captions.append('1')
                     else:
                         vimeo_captions.append('2')
+
                 if '1' in vimeo_captions:
-                    vimeo_link[link] = ['Captions in English', '', '', ''] + vimeo_link[link]
+                    r = requests.get(
+                        'https://api.vimeo.com/videos/{}'.format(video_id),
+                        headers={'Authorization': 'Bearer {}'.format(vimeo_api_key)}
+                    )
+                    data = r.json()
+                    vimeo_duration = data['duration']
+                    vimeo_link[link] = ['Captions in English', '', '', vimeo_duration] + vimeo_link[link]
                 else:
                     r = requests.get(
                         'https://api.vimeo.com/videos/{}'.format(video_id),

--- a/vast.py
+++ b/vast.py
@@ -54,23 +54,25 @@ def get_youtube_video_length(response, youtube_link):
         # Update the appropriate time value in the youtube_link
         youtube_link[YOUTUBE_TIMESTAMP_POSITION_MAP[timestamp[-1]]] = timestamp[:-1]
 
-def get_vimeo_video_length(response, video_id):
-    """
-    Determines the length of a Vimeo video from the video ID provides and updates the information in VAST report accordingly.
-
-    :param response: The response from the Vimeo Video API.
-    :type response: requests.Response
-    :param video_id: The ID of the Vimeo video.
-    :type video_id: int
-    """
-
-    # Parse the Vimeo URL to recieve the video_id
-
-    # Send a GET request to the api.vimeo.com/videos/{video_id} endpoint
-
-    # Receive the 'duration' field from the provided response
-
-    # Populate the appropriate column in the VAST report with seconds
+# def get_vimeo_video_length(response, vimeo_link):
+#     """
+#     Determines the length of a Vimeo video and updates the information in VAST report accordingly.
+#
+#     :param response: The response from the Vimeo Video API.
+#     :type response: requests.Response
+#     :param vimeo_link: The data structure holding information about the Vimeo video.
+#     :type vimeo_link: List
+#     """
+#
+#     # Send a GET request of the vimeo_link URL to the api.vimeo.com/videos?links={} endpoint
+#
+#     # Parse the 'video_id' field from the provided response
+#
+#     # Send a GET request to the api.vimeo.com/videos/{video_id} endpoint
+#
+#     # Parse the 'duration' field from the provided response
+#
+#     # Populate the appropriate column in the VAST report with seconds
 
 # Checks all pages in a canvas course for media links
 print('Checking Pages')
@@ -297,11 +299,11 @@ for link in vimeo_link:
                 )
                 data = r.json()
                 vimeo_duration = data['duration']
-                hour, remainder = divmod(vimeo_duration, 3600)
-                minute, second = divmod(remainder, 60)
-                vimeo_link[link].insert(1, hour)
-                vimeo_link[link].insert(2, minute)
-                vimeo_link[link].insert(3, second)
+                # hour, remainder = divmod(vimeo_duration, 3600)
+                # minute, second = divmod(remainder, 60)
+                vimeo_link[link].insert(1, '')
+                vimeo_link[link].insert(2, '')
+                vimeo_link[link].insert(3, vimeo_duration)
             else:
                 for d in data['data']:
                     if d['language'] == 'en' or d['language'] == 'en-US':
@@ -317,9 +319,7 @@ for link in vimeo_link:
                     )
                     data = r.json()
                     vimeo_duration = data['duration']
-                    hour, remainder = divmod(vimeo_duration, 3600)
-                    minute, second = divmod(remainder, 60)
-                    vimeo_link[link] = ['No English Captions', hour, minute, second] + vimeo_link[link]
+                    vimeo_link[link] = ['No English Captions', '', '', vimeo_duration] + vimeo_link[link]
 
         except KeyError:
             vimeo_link[link] = ['Unable to Check Vimeo Video.', '', '', ''] + vimeo_link[link]
@@ -346,11 +346,11 @@ for link in vimeo_link:
                 )
                 data = r.json()
                 vimeo_duration = data['duration']
-                hour, remainder = divmod(vimeo_duration, 3600)
-                minute, second = divmod(remainder, 60)
-                vimeo_link[link].insert(1, hour)
-                vimeo_link[link].insert(2, minute)
-                vimeo_link[link].insert(3, second)
+                # hour, remainder = divmod(vimeo_duration, 3600)
+                # minute, second = divmod(remainder, 60)
+                vimeo_link[link].insert(1, '')
+                vimeo_link[link].insert(2, '')
+                vimeo_link[link].insert(3, vimeo_duration)
             else:
                 for d in data['data']:
                     if d['language'] == 'en' or d['language'] == 'en-US':
@@ -370,11 +370,11 @@ for link in vimeo_link:
                     )
                     data = r.json()
                     vimeo_duration = data['duration']
-                    hour, remainder = divmod(vimeo_duration, 3600)
-                    minute, second = divmod(remainder, 60)
-                    vimeo_link[link].insert(1, hour)
-                    vimeo_link[link].insert(2, minute)
-                    vimeo_link[link].insert(3, second)
+                    # hour, remainder = divmod(vimeo_duration, 3600)
+                    # minute, second = divmod(remainder, 60)
+                    vimeo_link[link].insert(1, '')
+                    vimeo_link[link].insert(2, '')
+                    vimeo_link[link].insert(3, vimeo_duration)
         except KeyError:
             vimeo_link[link].insert(0, 'Unable to Check Vimeo Video')
             vimeo_link[link].insert(1, '')

--- a/vast.py
+++ b/vast.py
@@ -288,22 +288,15 @@ for link in vimeo_link:
                         vimeo_captions.append('1')
                     else:
                         vimeo_captions.append('2')
-
+                r = requests.get(
+                    'https://api.vimeo.com/videos/{}'.format(video_id),
+                    headers={'Authorization': 'Bearer {}'.format(vimeo_api_key)}
+                )
+                data = r.json()
+                vimeo_duration = data['duration']
                 if '1' in vimeo_captions:
-                    r = requests.get(
-                        'https://api.vimeo.com/videos/{}'.format(video_id),
-                        headers={'Authorization': 'Bearer {}'.format(vimeo_api_key)}
-                    )
-                    data = r.json()
-                    vimeo_duration = data['duration']
                     vimeo_link[link] = ['Captions in English', '', '', vimeo_duration] + vimeo_link[link]
                 else:
-                    r = requests.get(
-                        'https://api.vimeo.com/videos/{}'.format(video_id),
-                        headers={'Authorization': 'Bearer {}'.format(vimeo_api_key)}
-                    )
-                    data = r.json()
-                    vimeo_duration = data['duration']
                     vimeo_link[link] = ['No English Captions', '', '', vimeo_duration] + vimeo_link[link]
 
         except KeyError:


### PR DESCRIPTION
Resolves #22 

10/14
Issue ended up being resolved much easier than previously thought; the code already sends a GET request to the Vimeo Video API endpoint for receiving a duration of a video. I modified the code to populate the `Seconds` column in the VAST report to hold the value returned in `duration`, since Rev needs the full length of a given Vimeo video in seconds (not split into hours / minutes). 

10/19
I refactored the code to remove duplicated calls to the API as well as ensured videos that are marked as `Captions in English` contain their respective video durations.